### PR TITLE
Add compatibility for Create: Bitterballen

### DIFF
--- a/data/c/tags/item/sugar.json
+++ b/data/c/tags/item/sugar.json
@@ -1,0 +1,8 @@
+{
+  "values": [
+    {
+      "id": "minecraft:sugar",
+      "required": false
+    }
+  ]
+}

--- a/data/engineeredcompatibility/recipe/crusher/create_bitterballen/crushed_nether_wart.json
+++ b/data/engineeredcompatibility/recipe/crusher/create_bitterballen/crushed_nether_wart.json
@@ -1,0 +1,20 @@
+{
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "create_bic_bit"
+    }
+  ],
+  "type": "immersiveengineering:crusher",
+  "energy": 1600,
+  "input": {
+    "tag": "c:crops/nether_wart"
+  },
+  "result": {
+    "basePredicate": {
+      "item": "create_bic_bit:crushed_nether_wart"
+    },
+    "count": 1
+  },
+  "secondaries": []
+}

--- a/data/engineeredcompatibility/recipe/crusher/create_bitterballen/crushed_sunflower_seeds.json
+++ b/data/engineeredcompatibility/recipe/crusher/create_bitterballen/crushed_sunflower_seeds.json
@@ -1,0 +1,20 @@
+{
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "create_bic_bit"
+    }
+  ],
+  "type": "immersiveengineering:crusher",
+  "energy": 1600,
+  "input": {
+    "item": "create_bic_bit:sunflower_seeds"
+  },
+  "result": {
+    "basePredicate": {
+      "item": "create_bic_bit:crushed_sunflower_seeds"
+    },
+    "count": 1
+  },
+  "secondaries": []
+}

--- a/data/engineeredcompatibility/recipe/crusher/create_bitterballen/sunflower_seeds.json
+++ b/data/engineeredcompatibility/recipe/crusher/create_bitterballen/sunflower_seeds.json
@@ -1,0 +1,28 @@
+{
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "create_bic_bit"
+    }
+  ],
+  "type": "immersiveengineering:crusher",
+  "energy": 1600,
+  "input": {
+    "item": "minecraft:sunflower"
+  },
+  "result": {
+    "basePredicate": {
+      "item": "create_bic_bit:sunflower_seeds"
+    },
+    "count": 1
+  },
+  "secondaries": [
+    {
+      "chance": 0.50,
+      "conditions": [],
+      "output": {
+        "item": "create_bic_bit:sunflower_seeds"
+      }
+    }
+  ]
+}

--- a/data/engineeredcompatibility/recipe/mixer/create/chocolate.json
+++ b/data/engineeredcompatibility/recipe/mixer/create/chocolate.json
@@ -1,0 +1,32 @@
+{
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "immersiveengineering:mixer",
+  "energy": 1600,
+  "fluid": {
+    "amount": 250,
+    "tag": "c:milk"
+  },
+  "inputs": [
+    {
+      "basePredicate": {
+        "tag": "c:sugar"
+      },
+      "count": 1
+    },
+    {
+      "basePredicate": {
+        "tag": "c:crops/cocoa_bean"
+      },
+      "count": 1
+    }
+  ],
+  "result": {
+    "amount": 250,
+    "id": "create:chocolate"
+  }
+}

--- a/data/engineeredcompatibility/recipe/mixer/create_bitterballen/curdled_milk.json
+++ b/data/engineeredcompatibility/recipe/mixer/create_bitterballen/curdled_milk.json
@@ -1,0 +1,26 @@
+{
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "create_bic_bit"
+    }
+  ],
+  "type": "immersiveengineering:mixer",
+  "energy": 1600,
+  "fluid": {
+    "amount": 250,
+    "tag": "c:milk"
+  },
+  "inputs": [
+    {
+      "basePredicate": {
+        "item": "create_bic_bit:crushed_nether_wart"
+      },
+      "count": 1
+    }
+  ],
+  "result": {
+    "amount": 250,
+    "id": "create_bic_bit:curdled_milk"
+  }
+}

--- a/data/engineeredcompatibility/recipe/mixer/create_bitterballen/frying_oil.json
+++ b/data/engineeredcompatibility/recipe/mixer/create_bitterballen/frying_oil.json
@@ -1,0 +1,26 @@
+{
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "create_bic_bit"
+    }
+  ],
+  "type": "immersiveengineering:mixer",
+  "energy": 1600,
+  "fluid": {
+    "amount": 250,
+    "tag": "c:water"
+  },
+  "inputs": [
+    {
+      "basePredicate": {
+        "item": "create_bic_bit:crushed_sunflower_seeds"
+      },
+      "count": 1
+    }
+  ],
+  "result": {
+    "amount": 250,
+    "id": "create_bic_bit:frying_oil"
+  }
+}

--- a/data/engineeredcompatibility/recipe/mixer/create_bitterballen/ketchup.json
+++ b/data/engineeredcompatibility/recipe/mixer/create_bitterballen/ketchup.json
@@ -1,0 +1,38 @@
+{
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "create_bic_bit"
+    }
+  ],
+  "type": "immersiveengineering:mixer",
+  "energy": 1600,
+  "fluid": {
+    "amount": 250,
+    "tag": "c:water"
+  },
+  "inputs": [
+    {
+      "basePredicate": {
+        "tag": "c:sugar"
+      },
+      "count": 1
+    },
+    {
+      "basePredicate": {
+        "item": "create_bic_bit:crushed_nether_wart"
+      },
+      "count": 1
+    },
+    {
+      "basePredicate": {
+        "tag": "c:crops/beetroot"
+      },
+      "count": 2
+    }
+  ],
+  "result": {
+    "amount": 250,
+    "id": "create_bic_bit:ketchup"
+  }
+}

--- a/data/engineeredcompatibility/recipe/mixer/create_bitterballen/ketchup_tomato.json
+++ b/data/engineeredcompatibility/recipe/mixer/create_bitterballen/ketchup_tomato.json
@@ -1,0 +1,45 @@
+{
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "create_bic_bit"
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:tag_empty",
+        "tag": "c:crops/tomato"
+      }
+    }
+  ],
+  "type": "immersiveengineering:mixer",
+  "energy": 1600,
+  "fluid": {
+    "amount": 250,
+    "tag": "c:water"
+  },
+  "inputs": [
+    {
+      "basePredicate": {
+        "tag": "c:sugar"
+      },
+      "count": 1
+    },
+    {
+      "basePredicate": {
+        "item": "create_bic_bit:crushed_nether_wart"
+      },
+      "count": 1
+    },
+    {
+      "basePredicate": {
+        "tag": "c:crops/tomato"
+      },
+      "count": 2
+    }
+  ],
+  "result": {
+    "amount": 250,
+    "id": "create_bic_bit:ketchup"
+  }
+}

--- a/data/engineeredcompatibility/recipe/mixer/create_bitterballen/mayonnaise.json
+++ b/data/engineeredcompatibility/recipe/mixer/create_bitterballen/mayonnaise.json
@@ -1,0 +1,26 @@
+{
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "create_bic_bit"
+    }
+  ],
+  "type": "immersiveengineering:mixer",
+  "energy": 1600,
+  "fluid": {
+    "amount": 250,
+    "tag": "c:milk"
+  },
+  "inputs": [
+    {
+      "basePredicate": {
+        "tag": "c:eggs"
+      },
+      "count": 3
+    }
+  ],
+  "result": {
+    "amount": 250,
+    "id": "create_bic_bit:mayonnaise"
+  }
+}


### PR DESCRIPTION
This PR adds:

- The tag "c:sugar" for minecraft:sugar (I have seen other variations like "c:sugars" and "c:sugar/sugar", but "c:sugar" is the most common one from what I could find)
- Mixer recipe for create chocolate
- Mixing recipes for ketchup, mayonnaise, frying oil and curdled milk from create: bitterballen
- Crushing recipes for (crushed) sunflower seeds and crushed nether wart from create: bitterballen